### PR TITLE
feat: add concurrency control to deployment workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,6 +45,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     if: github.ref == 'refs/heads/main'
+    concurrency:
+      group: deploy
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v5
       - name: Use Node.js 24.x


### PR DESCRIPTION
## Summary
- Adds concurrency control to the `release` job in the main workflow
- Ensures only one deployment runs at a time
- Queues deployments instead of canceling them (`cancel-in-progress: false`)

## Details
This change implements workflow concurrency control as per [GitHub's documentation](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency) to ensure that only one deployment can run at a time. By setting `cancel-in-progress: false`, older runs will queue up and execute sequentially rather than being canceled.

This prevents race conditions and deployment conflicts when multiple commits are pushed to main in quick succession.

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Test with multiple rapid pushes to main (after merge) to confirm deployments queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)